### PR TITLE
two typos in the output of summary.migration.summary

### DIFF
--- a/R/summary_functions.R
+++ b/R/summary_functions.R
@@ -96,8 +96,8 @@ stationary.migration.summary<-function(Result, prob.cutoff=0.1, min.stay=3) {
    Total_sites<-nrow(Res$Potential_stat_periods)
    
    cat('\n\n\nFLightR used',round(Duration), attr(Duration, 'units'), 'from', format(Result$Indices$Matrix.Index.Table$time[1], format='%d-%b-%Y'), 'to', format(rev(Result$Indices$Matrix.Index.Table$time)[1], format='%d-%b-%Y') , 'with', Total_twilights, 'twilights\n')
-   cat('During this time tag moved approximately', round(max(Res$Stationary.periods$Distance2cumulative)), 'km with', nrow(Res$Stationary.periods), 'statiuonary periods from which', length(which(Res$Potential_stat_periods$Duration>30)), 'were longer than two weeks\n')
-   cat('\n\n Detected statonary periods (without any merging!):\n')
+   cat('During this time tag moved approximately', round(max(Res$Stationary.periods$Distance2cumulative)), 'km with', nrow(Res$Stationary.periods), 'stationary periods from which', length(which(Res$Potential_stat_periods$Duration>30)), 'were longer than two weeks\n')
+   cat('\n\n Detected stationary periods (without any merging!):\n')
    print(Res$Stationary.periods[,c(4,7, 12,15,23, 24, 27, 32)])
    return(Res)
    }


### PR DESCRIPTION
the output of summary.migration.summary had two typos of the word stationary. I fixed them. 